### PR TITLE
docs: create centralized RESOURCES.md for the cohort

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ### team meeting minutes and design discussions
 
 Jan 27, 2026
-Attendees: hana-banana, hayden, Kevin, Amanda<put your name here>
+Attendees: hana-banana, hayden, Kevin, Amanda, Rosa<put your name here>
 Minutes: 
  - Worked on MVP user stories. Discussed our learning goals for the cohort time period. Discussed planned AI use if any.
  - Agreed to meet once more before Feb 2nd to finalize tech stack discussions with remainder of team

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ### team meeting minutes and design discussions
 
 Jan 27, 2026
-Attendees: hana-banana, hayden, Kevin, Amanda, Rosa<put your name here>
+Attendees: hana-banana, hayden, Kevin, Amanda<put your name here>
 Minutes: 
  - Worked on MVP user stories. Discussed our learning goals for the cohort time period. Discussed planned AI use if any.
  - Agreed to meet once more before Feb 2nd to finalize tech stack discussions with remainder of team

--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -1,0 +1,30 @@
+# Project Resources - Jade Jasmine Team
+
+This document centralizes all resources, documentation, and tools for the Community Pantry Tracker project (Spring Cohort 2026).
+
+## Tech Stack and Documentation
+- [Node.js Documentation](https://nodejs.org/docs/latest/api/)
+- [Express.js Guide](https://expressjs.com/en/guide/routing.html)
+- [PostgreSQL Tutorial](https://www.postgresql.org/docs/)
+- [MUI Documentation](https://mui.com/material-ui/)
+- [Astro Getting Started](https://docs.astro.build/en/getting-started/)
+
+## Design and Research
+- [Figma Design File](https://www.figma.com/site/C7oen9TPCcU1lblgvTq8Gy/Untitled?node-id=2-139)
+- [OpenFoodFacts API Docs](https://world.openfoodfacts.org/api)
+
+## Learning Material
+- [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+- [Git Workflow](https://www.git-scm.com/docs)
+- [Git For Teams](https://www.youtube.com/watch?v=xhzLIfJYTLs)
+- [GitHub](https://github.com)
+- [Astro Tutorial](https://docs.astro.build/en/tutorial/0-introduction/)
+- [User Stories](https://docs.nhcarrigan.com/mentorship/resources/user-stories/)
+- [Technical Breakdown](https://docs.nhcarrigan.com/mentorship/resources/technical-breakdown/)
+- [Project Planning](https://docs.nhcarrigan.com/mentorship/resources/project-planning/)
+- [Code Development](https://docs.nhcarrigan.com/mentorship/resources/code-development/)
+- [Code Review Checklist](https://docs.nhcarrigan.com/mentorship/resources/code-review-checklist/)
+- [Final Polish](https://docs.nhcarrigan.com/mentorship/resources/final-polish/)
+- [Flask Tutorials](https://www.youtube.com/playlist?list=PL-osiE80TeTs4UjLw5MM6OjgkjFeUxCYH)
+---
+

--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -19,6 +19,7 @@ This document centralizes all resources, documentation, and tools for the Commun
 - [Git For Teams](https://www.youtube.com/watch?v=xhzLIfJYTLs)
 - [GitHub](https://github.com)
 - [Astro Tutorial](https://docs.astro.build/en/tutorial/0-introduction/)
+- [freeCodeCamp Astro Tutorial](https://www.youtube.com/watch?v=e-hTm5VmofI)
 - [User Stories](https://docs.nhcarrigan.com/mentorship/resources/user-stories/)
 - [Technical Breakdown](https://docs.nhcarrigan.com/mentorship/resources/technical-breakdown/)
 - [Project Planning](https://docs.nhcarrigan.com/mentorship/resources/project-planning/)


### PR DESCRIPTION
**Description**
Following our team discussion on Discord, I have created a dedicated space to centralize project resources. This will help prevent useful links and documentation from getting lost in the chat history.

**Changes**
- Created RESOURCES.md in the root directory.
- Added initial documentation for Tech Stack (Node, Express, MUI, Astro).
- Included links to Figma design and OpenFoodFacts API.
- Added a "Learning Material" section with Git and Project Planning guides.

**Related Issues**
Closes #20